### PR TITLE
Add basic Culture Puzzle web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# CulturePuzzle
+# Culture Puzzle
+
+A simple educational puzzle game that teaches cultural facts through drag-and-drop puzzles. Complete puzzles to unlock new regions and learn about cultural elements such as clothing, landmarks and animals.
+
+## Running
+Open `index.html` in a modern web browser. Progress is saved locally using `localStorage`.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Culture Puzzle</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div id="app">
+        <header>
+            <h1>Culture Puzzle</h1>
+            <button id="dashboardBtn">Dashboard</button>
+        </header>
+        <main id="game"></main>
+        <div id="infoPanel" class="hidden">
+            <h2>Culture Info</h2>
+            <div id="infoContent"></div>
+            <button id="closeInfo">Close</button>
+        </div>
+    </div>
+    <div id="dashboard" class="hidden"></div>
+    <script src="levels.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/levels.js
+++ b/levels.js
@@ -1,0 +1,21 @@
+// Example levels with placeholder content
+const levels = [
+    {
+        id: 'japan',
+        name: 'Japan',
+        pieces: [
+            { id: 'kimono', label: 'Kimono', info: 'Traditional Japanese clothing.' },
+            { id: 'fuji', label: 'Mt. Fuji', info: 'Iconic Japanese landmark.' },
+            { id: 'crane', label: 'Red-crowned Crane', info: 'Native bird of Japan.' }
+        ]
+    },
+    {
+        id: 'egypt',
+        name: 'Egypt',
+        pieces: [
+            { id: 'pyramid', label: 'Pyramid', info: 'Ancient Egyptian architecture.' },
+            { id: 'camel', label: 'Camel', info: 'Common animal in Egypt.' },
+            { id: 'papyrus', label: 'Papyrus', info: 'Early form of paper.' }
+        ]
+    }
+];

--- a/script.js
+++ b/script.js
@@ -1,0 +1,116 @@
+let currentLevelIndex = 0;
+let inactivityTimer = null;
+const game = document.getElementById('game');
+const infoPanel = document.getElementById('infoPanel');
+const infoContent = document.getElementById('infoContent');
+const dashboard = document.getElementById('dashboard');
+const dashboardBtn = document.getElementById('dashboardBtn');
+const closeInfo = document.getElementById('closeInfo');
+
+// Load progress from localStorage
+let progress = JSON.parse(localStorage.getItem('progress')) || {};
+
+function saveProgress() {
+    localStorage.setItem('progress', JSON.stringify(progress));
+}
+
+function showDashboard() {
+    dashboard.innerHTML = '<h2>Progress</h2>';
+    levels.forEach((lvl, idx) => {
+        const status = progress[lvl.id] ? 'Completed' : 'Locked';
+        const div = document.createElement('div');
+        div.textContent = `${lvl.name}: ${status}`;
+        dashboard.appendChild(div);
+    });
+    dashboard.classList.remove('hidden');
+}
+
+dashboardBtn.addEventListener('click', () => {
+    if (dashboard.classList.contains('hidden')) {
+        showDashboard();
+    } else {
+        dashboard.classList.add('hidden');
+    }
+});
+
+closeInfo.addEventListener('click', () => {
+    infoPanel.classList.add('hidden');
+});
+
+function loadLevel(index) {
+    currentLevelIndex = index;
+    game.innerHTML = '';
+    dashboard.classList.add('hidden');
+    const level = levels[index];
+
+    level.pieces.forEach(piece => {
+        const pieceEl = document.createElement('div');
+        pieceEl.className = 'piece';
+        pieceEl.textContent = piece.label;
+        pieceEl.draggable = true;
+        pieceEl.id = piece.id;
+        pieceEl.addEventListener('dragstart', () => startDrag(pieceEl));
+        pieceEl.addEventListener('click', () => selectPiece(pieceEl));
+        game.appendChild(pieceEl);
+
+        const zone = document.createElement('div');
+        zone.className = 'dropzone';
+        zone.dataset.piece = piece.id;
+        zone.addEventListener('dragover', e => e.preventDefault());
+        zone.addEventListener('drop', e => onDrop(e, pieceEl, zone, piece.info));
+        game.appendChild(zone);
+    });
+}
+
+function selectPiece(el) {
+    clearTimeout(inactivityTimer);
+    inactivityTimer = setTimeout(() => showHint(el.id), 5000);
+}
+
+function showHint(pieceId) {
+    const zone = [...document.querySelectorAll('.dropzone')].find(z => z.dataset.piece === pieceId);
+    if (zone) {
+        zone.classList.add('hint');
+        setTimeout(() => zone.classList.remove('hint'), 2000);
+    }
+}
+
+function startDrag(el) {
+    el.classList.remove('incorrect', 'correct');
+    clearTimeout(inactivityTimer);
+}
+
+function onDrop(event, pieceEl, zone, info) {
+    event.preventDefault();
+    if (zone.dataset.piece === pieceEl.id) {
+        zone.appendChild(pieceEl);
+        pieceEl.classList.add('correct');
+        pieceEl.draggable = false;
+        checkCompletion(info);
+    } else {
+        pieceEl.classList.add('incorrect');
+    }
+}
+
+function checkCompletion(info) {
+    const remaining = document.querySelectorAll('.piece[draggable="true"]');
+    if (remaining.length === 0) {
+        const level = levels[currentLevelIndex];
+        progress[level.id] = true;
+        saveProgress();
+        infoContent.textContent = level.pieces.map(p => p.info).join('\n');
+        infoPanel.classList.remove('hidden');
+        const nextIndex = currentLevelIndex + 1;
+        if (nextIndex < levels.length) {
+            const nextBtn = document.createElement('button');
+            nextBtn.textContent = 'Next Level';
+            nextBtn.addEventListener('click', () => loadLevel(nextIndex));
+            infoPanel.appendChild(nextBtn);
+        }
+    }
+}
+
+window.addEventListener('load', () => {
+    const firstUnlocked = levels.findIndex(lvl => !progress[lvl.id]);
+    loadLevel(firstUnlocked === -1 ? 0 : firstUnlocked);
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,78 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+}
+
+header {
+    background-color: #333;
+    color: white;
+    padding: 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+#game {
+    flex: 1;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    padding: 10px;
+}
+
+.piece, .dropzone {
+    width: 100px;
+    height: 100px;
+    margin: 5px;
+    border: 2px dashed #aaa;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    user-select: none;
+}
+
+.piece {
+    border-style: solid;
+    background-color: #f5f5f5;
+    cursor: grab;
+}
+
+.correct {
+    border-color: green;
+}
+
+.incorrect {
+    border-color: red;
+}
+
+.hidden {
+    display: none;
+}
+
+#infoPanel {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: white;
+    border: 1px solid #ccc;
+    padding: 10px;
+    z-index: 100;
+}
+
+#dashboard {
+    padding: 10px;
+}
+
+.hint {
+    animation: hintBlink 0.5s alternate 3;
+}
+
+@keyframes hintBlink {
+    from { background-color: yellow; }
+    to { background-color: transparent; }
+}


### PR DESCRIPTION
## Summary
- create simple HTML/CSS/JS web puzzle game
- implement drag and drop validation with hints and level progression
- provide dashboard and culture info panel
- include example levels for Japan and Egypt

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_686e3b54305483329a9f6cd1ab75b4a7